### PR TITLE
Adds public env var to cloudbuild script

### DIFF
--- a/cloudbuild.release.yaml
+++ b/cloudbuild.release.yaml
@@ -126,6 +126,7 @@ steps:
       - "BUCKET_KEY_PREFIX=fail-open"
       - "VERSION=$TAG_NAME"
       - "APPEND_REGION=true"
+      - "PUBLIC=true"
     args:
       - us-east-1
       - us-east-2


### PR DESCRIPTION
## Description of the change

Adds `PUBLIC` env var to cloudbuild script that was missing previously. This works to set up
the `acl` on the object in the public bucket.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing

Created a tag and ran the script, the object was public.
