### PR TITLE
ENG-8002: change dev builds to use commit sha and be public

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -122,20 +122,24 @@ steps:
     id: "upload-us-east-1"
     entrypoint: "scripts/publish.sh"
     env:
-      - "BUCKET=cyral-dev-artifacts"
+      - "BUCKET=cyral-public-assets-"
       - "BUCKET_KEY_PREFIX=fail-open"
-      - "VERSION=$BUILD_ID"
-      - "APPEND_REGION=false"
+      - "VERSION=$COMMIT_SHA"
+      - "APPEND_REGION=true"
+      - "PUBLIC=true"
     args:
       - us-east-1
+      - us-east-2
+      - us-west-1
+      - us-west-2
     waitFor: ["build-lambda-zip"]
     secretEnv: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY]
 
 
 availableSecrets:
   secretManager:
-    - versionName: projects/cyral-dev/secrets/github-aws-private-key-secret/versions/1
+    - versionName: projects/cyral-dev/secrets/github-aws-key-secret/versions/4
       env: AWS_SECRET_ACCESS_KEY
-    - versionName: projects/cyral-dev/secrets/github-aws-private-key-id/versions/1
+    - versionName: projects/cyral-dev/secrets/github-aws-key-id/versions/4
       env: AWS_ACCESS_KEY_ID
 


### PR DESCRIPTION
## Description of the change

Changes dev builds to use the public bucket and commit sha as version.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
Triggered a build and used the commit sha as version for the cft.
