### PR TITLE
Removes failing lint steps from cloudbuild

### DIFF
--- a/cloudbuild.release.yaml
+++ b/cloudbuild.release.yaml
@@ -63,30 +63,6 @@ steps:
     id: "unit-tests"
     waitFor: ["git-config"]
 
-  # Run security tests
-  - name: securego/gosec
-    args:
-      - -no-fail
-      - ./...
-    volumes:
-      - name: "go-modules"
-        path: /go
-    id: "security-tests"
-    waitFor: ["unit-tests"]
-
-  # Run lint
-  - name: golangci/golangci-lint
-    args:
-      - golangci-lint
-      - run
-      - --issues-exit-code=0
-      - --timeout=5m
-    volumes:
-      - name: "go-modules"
-        path: /go
-    id: "run lint"
-    waitFor: ["unit-tests"]
-
   # Build repo failopen binary
   - name: golang:1.17
     entrypoint: "make"


### PR DESCRIPTION
## Description of the change

Removes lints that are timing out on release cloudbuild step.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
> Description of testing
